### PR TITLE
Retry after tick

### DIFF
--- a/src/decorators/retry_node.cpp
+++ b/src/decorators/retry_node.cpp
@@ -51,35 +51,47 @@ NodeStatus RetryNode::tick()
 
   setStatus(NodeStatus::RUNNING);
 
-  while (try_count_ < max_attempts_ || max_attempts_ == -1)
+  if (try_count_ >= max_attempts_ && max_attempts_ != -1)
   {
-    NodeStatus child_state = child_node_->executeTick();
-    switch (child_state)
-    {
-      case NodeStatus::SUCCESS: {
-        try_count_ = 0;
-        resetChild();
-        return (NodeStatus::SUCCESS);
-      }
-
-      case NodeStatus::FAILURE: {
-        try_count_++;
-        resetChild();
-      }
-      break;
-
-      case NodeStatus::RUNNING: {
-        return NodeStatus::RUNNING;
-      }
-
-      default: {
-        throw LogicError("A child node must never return IDLE");
-      }
-    }
+    try_count_ = 0;
+    return BT::NodeStatus::FAILURE;
   }
 
-  try_count_ = 0;
-  return NodeStatus::FAILURE;
+  BT::NodeStatus child_state = child_node_->executeTick();
+  switch (child_state)
+  {
+    case BT::NodeStatus::SUCCESS:
+    {
+      try_count_ = 0;
+      resetChild();
+      return BT::NodeStatus::SUCCESS;
+    }
+
+    case BT::NodeStatus::FAILURE:
+    {
+      ++try_count_;
+      resetChild();
+      if (try_count_ < max_attempts_ || max_attempts_ == -1)
+      {
+        return BT::NodeStatus::RUNNING;
+      }
+      else
+      {
+        try_count_ = 0;
+        return BT::NodeStatus::FAILURE;
+      }
+    }
+
+    case BT::NodeStatus::RUNNING:
+    {
+      return BT::NodeStatus::RUNNING;
+    }
+
+    default:
+    {
+      throw BT::LogicError("A child node must never return IDLE");
+    }
+  }
 }
 
 }   // namespace BT

--- a/src/decorators/retry_node.cpp
+++ b/src/decorators/retry_node.cpp
@@ -71,15 +71,12 @@ NodeStatus RetryNode::tick()
     {
       ++try_count_;
       resetChild();
-      if (try_count_ < max_attempts_ || max_attempts_ == -1)
-      {
-        return BT::NodeStatus::RUNNING;
-      }
-      else
+      if (try_count_ >= max_attempts_ && max_attempts_ != -1)
       {
         try_count_ = 0;
         return BT::NodeStatus::FAILURE;
       }
+      return BT::NodeStatus::RUNNING;
     }
 
     case BT::NodeStatus::RUNNING:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(BT_TESTS
   gtest_subtree.cpp
   gtest_switch.cpp
   gtest_wakeup.cpp
+  gtest_retry.cpp
 )
 
 if( ZMQ_FOUND )

--- a/tests/gtest_retry.cpp
+++ b/tests/gtest_retry.cpp
@@ -4,10 +4,10 @@
 
 using BT::NodeStatus;
 
-class FinishAfterN : public BT::SyncActionNode
+class FlipN : public BT::SyncActionNode
 {
 public:
-  FinishAfterN(const std::string& name, int N, const NodeStatus initial_return_value):
+  FlipN(const std::string& name, int N, const NodeStatus initial_return_value):
     BT::SyncActionNode(name, {}), counter_(N), initial_return_value_(initial_return_value)
   {
   }
@@ -41,8 +41,8 @@ TEST(Retry, test)
 {
   BT::ReactiveSequence root("root");
   BT::RetryNode retry("retry", 2);
-  FinishAfterN condition_1("condition_1", 1, NodeStatus::SUCCESS);
-  FinishAfterN action_1("action_1", 1, NodeStatus::FAILURE);
+  FlipN condition_1("condition_1", 1, NodeStatus::SUCCESS);
+  FlipN action_1("action_1", 1, NodeStatus::FAILURE);
   root.addChild(&condition_1);
   retry.setChild(&action_1);
   root.addChild(&retry);

--- a/tests/gtest_retry.cpp
+++ b/tests/gtest_retry.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp_v3/decorators/retry_node.h"
+
+using BT::NodeStatus;
+
+class FinishAfterN : public BT::SyncActionNode
+{
+public:
+  FinishAfterN(const std::string& name, int N):
+    BT::SyncActionNode(name, {}), counter_(N)
+  {
+  }
+
+  NodeStatus tick() override
+  {
+    if (counter_-- > 0)
+    {
+      std::string msg = return_value == NodeStatus::SUCCESS ? "SUCCESS" : "FAILURE";
+      std::cout << name() << "; " << msg << std::endl;
+      return return_value;
+    }
+    else
+    {
+      if (return_value == NodeStatus::SUCCESS)
+      {
+        std::cout << name() << "; FAILURE" << std::endl;
+        return NodeStatus::FAILURE;
+      }
+      else
+      {
+        std::cout << name() << "; SUCCESS" << std::endl;
+        return NodeStatus::SUCCESS;
+      }
+    }
+  }
+
+  NodeStatus return_value = NodeStatus::SUCCESS;
+  private:
+    int counter_ = 0;
+};
+
+/**
+ * This test has a reactive sequence with a condition that return SUCCESS in the first tick and FAILURE in the second tick.
+ * The other child in the reactive sequence is an action with a retry decorator.
+ * The Action returns FAILURE in the first tick and SUCCESS in the second tick.
+ * The retry decorator has a max_attempts of 2.
+ *
+ * In the first tick, the condition returns SUCCESS, thus the action is ticked, but it returns FAILURE.
+ * Since the decorator is a retry, we expect it to return RUNNING.
+ * In the second tick, the condition return FAILURE, the retry should be halted and the action is not ticked.
+ * The result of the reactive sequence should be FAILURE.
+*/
+TEST(Retry, test)
+{
+  BT::ReactiveSequence root("root");
+  BT::RetryNode retry("retry", 2);
+  FinishAfterN condition_1("condition_1", 1);
+  FinishAfterN action_1("action_1", 1);
+  root.addChild(&condition_1);
+  retry.setChild(&action_1);
+  root.addChild(&retry);
+
+  condition_1.return_value = BT::NodeStatus::SUCCESS;
+  action_1.return_value = BT::NodeStatus::FAILURE;
+
+  BT::NodeStatus status = root.executeTick();
+  ASSERT_EQ(status, BT::NodeStatus::RUNNING);
+
+  status = root.executeTick();
+  ASSERT_EQ(status, BT::NodeStatus::FAILURE);
+}
+
+


### PR DESCRIPTION
## Description
wrike: https://www.wrike.com/open.htm?id=1266417999

The `RetryUntilSuccessful` action retries the child on the SAME tick, so the flow looks like:
1) `ExePathAction` fails
2) `Recover` fails (not recoverable error)
3) `RetryUntilSuccessful` retries `ExePathAction` again in the same tick
4) `ExePathAction` returns running
5) `RetryUntilSuccessful` returns running
 We move to the next tick
6) `IsBoolTrue` detects that the error is not recoverable, halt the `RetryUntilSuccessful` and we exit the tree

So we run PF twice before returning

To fix this it is NOT enough to swap the order of the reactive sequence and the retry action, because the reaction will return `FAILURE` and BT gets stuck in infinity loop on the retry.
We would need to store variables to know if the failure was because of recover or execution, which is a bit messy.

I have created a new decorator with the expected behavior and an unittest for that.

| <video src="https://github.com/rapyuta-robotics/rr_navigation/assets/6097267/d5886564-a1dc-45cb-8fd5-c41d29fea3f6" >   |  <video src="https://github.com/rapyuta-robotics/rr_navigation/assets/6097267/789d5c8b-f5ee-402a-ba78-8a80962f40e8">  |
|---|---|
| before | after  |