### PR TITLE
Make ReservedPortNames a static array, so accessing it from a static BTFactory doesn't crash

### DIFF
--- a/include/behaviortree_cpp_v3/basic_types.h
+++ b/include/behaviortree_cpp_v3/basic_types.h
@@ -5,7 +5,6 @@
 #include <vector>
 #include <sstream>
 #include <unordered_map>
-#include <unordered_set>
 #include <typeinfo>
 #include <functional>
 #include <chrono>
@@ -216,7 +215,7 @@ using Optional = nonstd::expected<T, std::string>;
  * */
 using Result = Optional<void>;
 
-const std::unordered_set<std::string> ReservedPortNames = {"ID", "name", "_description"};
+static const std::array<std::string, 3> ReservedPortNames = {"ID", "name", "_description"};
 
 class PortInfo
 {
@@ -271,7 +270,7 @@ std::pair<std::string, PortInfo> CreatePort(PortDirection direction, StringView 
                                             StringView description = {})
 {
   auto sname = static_cast<std::string>(name);
-  if (ReservedPortNames.count(sname) != 0)
+  if (std::count(ReservedPortNames.begin(), ReservedPortNames.end(), sname) != 0)
   {
     throw std::runtime_error("A port can not use a reserved name. See ReservedPortNames");
   }

--- a/src/xml_parsing.cpp
+++ b/src/xml_parsing.cpp
@@ -523,7 +523,7 @@ TreeNode::Ptr XMLParser::Pimpl::createNodeFromXML(const XMLElement* element,
     for (const XMLAttribute* att = element->FirstAttribute(); att; att = att->Next())
     {
       const std::string attribute_name = att->Name();
-      if (ReservedPortNames.count(attribute_name) == 0)
+      if (std::count(ReservedPortNames.begin(), ReservedPortNames.end(), attribute_name) == 0)
       {
         port_remap[attribute_name] = att->Value();
       }
@@ -699,7 +699,7 @@ void BT::XMLParser::Pimpl::recursivelyCreateTree(const std::string& tree_ID,
           for (const XMLAttribute* attr = element->FirstAttribute(); attr != nullptr;
                attr = attr->Next())
           {
-            if (ReservedPortNames.count(attr->Name()) == 0)
+            if (std::count(ReservedPortNames.begin(), ReservedPortNames.end(), attr->Name()) == 0)
             {
               new_bb->addSubtreeRemapping(attr->Name(), attr->Value());
             }
@@ -720,7 +720,7 @@ void BT::XMLParser::Pimpl::recursivelyCreateTree(const std::string& tree_ID,
           const char* attr_name = attr->Name();
           const char* attr_value = attr->Value();
 
-          if (ReservedPortNames.count(attr->Name()) != 0)
+          if (std::count(ReservedPortNames.begin(), ReservedPortNames.end(), attr->Name()) != 0)
           {
             continue;
           }
@@ -779,7 +779,7 @@ void XMLParser::Pimpl::getPortsRecursively(const XMLElement* element,
   {
     const char* attr_name = attr->Name();
     const char* attr_value = attr->Value();
-    if (ReservedPortNames.count(attr_name) == 0 &&
+    if (std::count(ReservedPortNames.begin(), ReservedPortNames.end(), attr_name) == 0 &&
         TreeNode::isBlackboardPointer(attr_value))
     {
       auto port_name = TreeNode::stripBlackboardPointer(attr_value);


### PR DESCRIPTION
Required for https://github.com/rapyuta-robotics/rr_navigation/pull/1820
Otherwise I get this rather cryptic error:
```
(gdb) bt
#0  0x00005555556290a1 in std::__detail::_Mod_range_hashing::operator() (this=0x5555556c1f40 <BT::ReservedPortNames>, __num=2133999577744268061, __den=0) at /usr/include/c++/9/bits/hashtable_policy.h:433
#1  0x0000555555639b68 in std::__detail::_Hash_code_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__detail::_Identity, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, true>::_M_bucket_index (this=0x5555556c1f40 <BT::ReservedPortNames>, __c=2133999577744268061, __n=0) at /usr/include/c++/9/bits/hashtable_policy.h:1390
#2  0x0000555555637240 in std::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Identity, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >::_M_bucket_index (this=0x5555556c1f40 <BT::ReservedPortNames>, __k="msec", __c=2133999577744268061) at /usr/include/c++/9/bits/hashtable.h:676
#3  0x0000555555634b48 in std::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Identity, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, true, true> >::count (this=0x5555556c1f40 <BT::ReservedPortNames>, __k="msec") at /usr/include/c++/9/bits/hashtable.h:1485
#4  0x0000555555630df3 in std::unordered_set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >::count
    (this=0x5555556c1f40 <BT::ReservedPortNames>, __x="msec") at /usr/include/c++/9/bits/unordered_set.h:669
#5  0x000055555562e77e in BT::CreatePort<unsigned int> (direction=BT::PortDirection::INPUT, name=..., description=...) at /home/jorge/catkin_ws/executive/src/btcpp/include/behaviortree_cpp_v3/basic_types.h:274
#6  0x00007ffff796e65a in BT::BehaviorTreeFactory::BehaviorTreeFactory() () from /home/jorge/rapyuta_ws/io_amr/devel/lib/libbehaviortree_cpp_v3.so
#7  0x00007ffff72c6838 in __static_initialization_and_destruction_0 (__initialize_p=1, __priority=65535) at /home/jorge/rapyuta_ws/io_amr/src/rr_navigation/rr_nav_servers/src/nas_strategy.cpp:68
#8  0x00007ffff72c6a9f in _GLOBAL__sub_I_nas_strategy.cpp(void) () at /home/jorge/rapyuta_ws/io_amr/src/rr_navigation/rr_nav_servers/src/nas_strategy.cpp:312
#9  0x00007ffff7fe0b9a in call_init (l=<optimized out>, argc=argc@entry=5, argv=argv@entry=0x7fffffff9c98, env=env@entry=0x7fffffff9cc8) at dl-init.c:72
#10 0x00007ffff7fe0ca1 in call_init (env=0x7fffffff9cc8, argv=0x7fffffff9c98, argc=5, l=<optimized out>) at dl-init.c:30
#11 _dl_init (main_map=0x7ffff7ffe190, argc=5, argv=0x7fffffff9c98, env=0x7fffffff9cc8) at dl-init.c:119
#12 0x00007ffff7fd013a in _dl_start_user () from /lib64/ld-linux-x86-64.so.2
```

tbh, I have no clue why the current code doesn't work, being `ReservedPortNames` a global variable.
Looking at the error, must be something about hashing the strings.
This PR avoids the problem entirely by using an array instead of a `unordered_set`

I also opened a [PR to upstream](https://github.com/BehaviorTree/BehaviorTree.CPP/pull/719)