### PR TITLE
Add unset key method to blackboard and matching wrapper to TreeNode

### DIFF
--- a/include/behaviortree_cpp_v3/blackboard.h
+++ b/include/behaviortree_cpp_v3/blackboard.h
@@ -165,8 +165,10 @@ public:
       // No entry, nothing to do.
       return;
     }
-
-    storage_.erase(it);
+//it->second->value = Any();
+it->second.reset();
+//std::cout << "\n" << it->second->value.empty()  << "\n";
+    //storage_.erase(it);
   }
 
   const PortInfo* portInfo(const std::string& key);

--- a/include/behaviortree_cpp_v3/blackboard.h
+++ b/include/behaviortree_cpp_v3/blackboard.h
@@ -92,6 +92,9 @@ public:
   template <typename T>
   void set(const std::string& key, const T& value)
   {
+    if (key.empty())
+      throw LogicError("Blackboard::set with empty key is not allowed");
+
     std::unique_lock<std::mutex> lock_entry(entry_mutex_);
     std::unique_lock<std::mutex> lock(mutex_);
 
@@ -142,13 +145,28 @@ public:
       {
         debugMessage();
 
-        throw LogicError("Blackboard::set() failed: once declared, the type of a port "
+        throw LogicError("Blackboard::set('", key, "') failed: once declared, the type of a port "
                          "shall not change. Declared type [",
                          BT::demangle(previous_type), "] != current type [",
                          BT::demangle(typeid(T)), "]");
       }
     }
     previous_any = std::move(new_value);
+  }
+
+  void unset(const std::string& key)
+  {
+    std::unique_lock lock(mutex_);
+
+    // check local storage
+    auto it = storage_.find(key);
+    if (it == storage_.end())
+    {
+      // No entry, nothing to do.
+      return;
+    }
+
+    storage_.erase(it);
   }
 
   const PortInfo* portInfo(const std::string& key);

--- a/include/behaviortree_cpp_v3/tree_node.h
+++ b/include/behaviortree_cpp_v3/tree_node.h
@@ -334,7 +334,11 @@ inline Result TreeNode::unsetOutput(const std::string& key)
   auto remap_it = config_.output_ports.find(key);
   if (remap_it == config_.output_ports.end())
   {
-    return {};
+    return nonstd::make_unexpected(StrCat("unsetOutput() failed: "
+                                          "NodeConfiguration::output_ports "
+                                          "does not "
+                                          "contain the key: [",
+                                          key, "]"));
   }
   StringView remapped_key = remap_it->second;
   if (remapped_key == "=")
@@ -345,7 +349,9 @@ inline Result TreeNode::unsetOutput(const std::string& key)
   {
     remapped_key = stripBlackboardPointer(remapped_key);
   }
-  config_.blackboard->unset(static_cast<std::string>(remapped_key));
+  //config_.blackboard->unset(static_cast<std::string>(remapped_key));
+  std::cerr  << "\n\n" << key  << "\t" << static_cast<std::string>(remapped_key)  << "\n\n";
+config_.blackboard->unset(key);
 
   return {};
 }

--- a/include/behaviortree_cpp_v3/tree_node.h
+++ b/include/behaviortree_cpp_v3/tree_node.h
@@ -166,6 +166,8 @@ public:
   template <typename T>
   Result setOutput(const std::string& key, const T& value);
 
+  Result unsetOutput(const std::string& key);
+
   // function provide mostrly for debugging purpose to see the raw value
   // in the port (no remapping and no conversion to a type)
   StringView getRawPortValue(const std::string& key) const;
@@ -317,6 +319,33 @@ inline Result TreeNode::setOutput(const std::string& key, const T& value)
     remapped_key = stripBlackboardPointer(remapped_key);
   }
   config_.blackboard->set(static_cast<std::string>(remapped_key), value);
+
+  return {};
+}
+
+inline Result TreeNode::unsetOutput(const std::string& key)
+{
+  if (!config_.blackboard)
+  {
+    return nonstd::make_unexpected("unsetOutput() failed: trying to access a "
+                                   "Blackboard(BB) entry, but BB is invalid");
+  }
+
+  auto remap_it = config_.output_ports.find(key);
+  if (remap_it == config_.output_ports.end())
+  {
+    return {};
+  }
+  StringView remapped_key = remap_it->second;
+  if (remapped_key == "=")
+  {
+    remapped_key = key;
+  }
+  if (isBlackboardPointer(remapped_key))
+  {
+    remapped_key = stripBlackboardPointer(remapped_key);
+  }
+  config_.blackboard->unset(static_cast<std::string>(remapped_key));
 
   return {};
 }


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=1288391306

BONUS: add debugging helpers to Blackboard::set to avoid misguiding error msgs